### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,21 +6,21 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-AD9851		KEYWORD1
-DDS		KEYWORD1
+AD9851	KEYWORD1
+DDS	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-dds_init		KEYWORD2
-pulse			KEYWORD2
-dds_reset		KEYWORD2
-calcDataWord KEYWORD2
-writeFreq	  	KEYWORD2
+dds_init	KEYWORD2
+pulse	KEYWORD2
+dds_reset	KEYWORD2
+calcDataWord	KEYWORD2
+writeFreq	KEYWORD2
 sweepTone	KEYWORD2
-sweepUp		KEYWORD2
-sweepDn		KEYWORD2
+sweepUp	KEYWORD2
+sweepDn	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords